### PR TITLE
(Bugfix) Ensure that `<dialog>` element has an accessible name assigned to it

### DIFF
--- a/assets/js/dialog-modal-element.js
+++ b/assets/js/dialog-modal-element.js
@@ -53,7 +53,9 @@ class DialogModalElement extends HTMLElement {
 
 		dialog = div.children[1];
 
-		dialog.appendChild(this.removeChild(this.children[0]));
+		dialog.appendChild(heading);
+
+		dialog.setAttribute('aria-labelledby', heading.id);
 
 		dialog.appendChild(closeControl);
 


### PR DESCRIPTION
Update the JavaScript to ensure that the `aria-labelledby` attribute is added to the `<dialog>` element. Set the attribute's value to equal the value of the `<dialog>` element's heading element's `id` attribute.